### PR TITLE
fix: formating stdout/stderr by process number

### DIFF
--- a/config.go
+++ b/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"gopkg.in/yaml.v3"
 	"os"
+	"strings"
 	"syscall"
 	"time"
 )
@@ -158,6 +159,13 @@ func parseProgram(prog YamlProgram) (Program, error) {
 	if err != nil {
 		return Program{}, err
 	}
+	if prog.Numproc != 1 && strings.Count(prog.Stdout, "(%d)") != 1 {
+		return Program{}, configError("program more than 1 process must have one '(%%d)' in stdout")
+	}
+	if prog.Numproc != 1 && strings.Count(prog.Stderr, "(%d)") != 1 {
+		return Program{}, configError("program more than 1 process must have one '(%%d)' in stderr")
+	}
+
 	env := parseEnv(prog.Environment)
 
 	p := Program{

--- a/controller.go
+++ b/controller.go
@@ -181,13 +181,13 @@ func (c *controller) startProc(ps *Proc) error {
 	if ps.Prog.Stdout == "" {
 		defer rStdout.Close()
 	} else {
-		go stdLog(ps.Prog.Stdout, rStdout)
+		go stdLog(ps.Stdout, rStdout)
 	}
 
 	if ps.Prog.Stderr == "" {
 		defer rStderr.Close()
 	} else {
-		go stdLog(ps.Prog.Stderr, rStderr)
+		go stdLog(ps.Stderr, rStderr)
 	}
 
 	go reapProc(c.ctx, proc, c.cmdCh)

--- a/server/taskserver/taskmaster.yaml
+++ b/server/taskserver/taskmaster.yaml
@@ -20,5 +20,5 @@ cluster:
           - SHELL: /bin/sh
           - HOME: /root
         umask: 022
-        stdout: /tmp/programname_stdout.log
-        stderr: /tmp/programname_stdout.log
+        stdout: /tmp/programname_stdout(%d).log
+        stderr: /tmp/programname_stderr(%d).log


### PR DESCRIPTION
force to use formatter '(%d)' when creating programs containing more than 1 processes.
'(%d)' should be showd only once in stdout/stderr configuration.