### PR TITLE
feat: Add Start in TaskCmd

### DIFF
--- a/proc.go
+++ b/proc.go
@@ -19,10 +19,10 @@ type Proc struct {
 	Prog   Program
 }
 
-type ProcStatus uint8
+type ProcStatus int32
 
 const (
-	ProcStopped ProcStatus = iota
+	ProcStopped ProcStatus = 1 << iota
 	ProcStopping
 	ProcStarting
 	ProcRunning
@@ -134,6 +134,23 @@ func isContainBackoff(procs []*Proc) bool {
 		}
 	}
 	return false
+}
+
+func checkStatus(procs []Proc, status ProcStatus, req CmdArg) bool {
+
+	for _, ps := range procs {
+		if req.Gname == "" || ps.Gname == req.Gname {
+			if req.Pname == "" || ps.Pname == req.Pname {
+				if req.Id < 0 || int(ps.Id) == req.Id {
+					if (ps.Status & status) == 0 {
+						return false
+					}
+				}
+			}
+		}
+	}
+
+	return true
 }
 
 func isAllProcDead(procs []Proc) bool {

--- a/server/taskserver/taskmaster.yaml
+++ b/server/taskserver/taskmaster.yaml
@@ -7,7 +7,7 @@ cluster:
         numproc: 2
         priority: 1
         directory: /tmp
-        autostart: 'Yes'
+        autostart: 'No'
         autorestart: always
         startsecs: 2
         startretries: 5
@@ -22,3 +22,23 @@ cluster:
         umask: 022
         stdout: /tmp/programname_stdout(%d).log
         stderr: /tmp/programname_stderr(%d).log
+      hoge:
+        cmd: ["/usr/bin/tail", "-f", "/var/log/messages"]
+        numproc: 12
+        priority: 1
+        directory: /tmp
+        autostart: 'No'
+        autorestart: always
+        startsecs: 2
+        startretries: 5
+        stopwaitsecs: 15
+        stopasgroup: 'No'
+        exitcodes:
+          - 0
+        stopsignal: TERM
+        environment:
+          - SHELL: /bin/sh
+          - HOME: /root
+        umask: 022
+        stdout: /tmp/hoge_stdout(%d).log
+        stderr: /tmp/hoge_stderr(%d).log


### PR DESCRIPTION
Add "Start command" to start process with unit of General, Group, Program or Process. Start command doesn't restart ongoing processes.
The unit of start should be determined by CmdArg
    If Gname is empty, Pname is empty, and Id is negative, the command is executed against All processes.
    If Gname is not empty, Pname is empty, and Id is negative, the command is executed against Group unit.
    If Gname is not empty, Pname is not empty, and Id is negative, the command is executed against Program unit.
    If Gname is not empty, Pname is not empty, and Id is non-negative, the command is executed against its process.

Currently The error could occur when the command is executed against its process.