### PR TITLE
fix: fails-when-omit-stdoutstderr-in-config#15

### DIFF
--- a/config.go
+++ b/config.go
@@ -159,10 +159,10 @@ func parseProgram(prog YamlProgram) (Program, error) {
 	if err != nil {
 		return Program{}, err
 	}
-	if prog.Numproc != 1 && strings.Count(prog.Stdout, "(%d)") != 1 {
+	if prog.Numproc != 1 && prog.Stdout != "" && strings.Count(prog.Stdout, "(%d)") != 1 {
 		return Program{}, configError("program more than 1 process must have one '(%%d)' in stdout")
 	}
-	if prog.Numproc != 1 && strings.Count(prog.Stderr, "(%d)") != 1 {
+	if prog.Numproc != 1 && prog.Stderr != "" && strings.Count(prog.Stderr, "(%d)") != 1 {
 		return Program{}, configError("program more than 1 process must have one '(%%d)' in stderr")
 	}
 

--- a/proc.go
+++ b/proc.go
@@ -54,8 +54,10 @@ func genProcs(groups map[string]Group) []*Proc {
 			Stdout := prog.Stdout
 			Stderr := prog.Stderr
 			for i := uint8(0); i < prog.Numproc; i++ {
-				if prog.Numproc != 1 {
+				if prog.Numproc != 1 && prog.Stdout != "" {
 					Stdout = replaceUint(prog.Stdout, "(%d)", i)
+				}
+				if prog.Numproc != 1 && prog.Stderr != "" {
 					Stderr = replaceUint(prog.Stderr, "(%d)", i)
 				}
 				p := &Proc{


### PR DESCRIPTION
bypassing format check when stdout/stderr is empty string.