### PR TITLE
fix: TaskServer doesn't fail when the socet file already exists#19

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -34,7 +34,11 @@ func Run(path string) error {
 		tCmd := t.NewTaskCmd(ctrl)
 
 		// cerate rpc Server
-		server := NewServer(cfg.Socket.Path, tCmd)
+		server, err := NewServer(cfg.Socket.Path, tCmd)
+		if err != nil {
+			return err
+		}
+
 		go server.Serve()
 
 		select {


### PR DESCRIPTION
It output error message like `listen unix /tmp/taskmaster.sock: bind: address already in use.`

Additionaly, set brand new Mux for http.DefaultServeMux every time creating server. It make TaskServer avoid reloading problem issued by #3