### PR TITLE
fix the process doesn't restart when os.StartProcess() failed #25

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -65,6 +65,7 @@ const (
 	procExit
 	procStartCheck
 	procStopCheck
+	procFail
 )
 
 type procCmd struct {


### PR DESCRIPTION
- As Is
    - the process doesn't restart when os.StartProcess() failed
    - it's because startProc doesn't call notify function but just returns error.

- To Be
    - call notify function in startProc.
    - since it doesn't have Pid, use CmdArg to specify which process needs to be retried.
    - the status will be changed inside startProc when os.StartProcess() failed