### PR TITLE
fix: Server hangs up when calling TaskCmd.Shutdown from client side #29

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -48,13 +48,13 @@ func Run(path string) error {
 				// stopping receiving request and handle current request
 				server.Shutdown()
 				// cleanup controller: stop all processes and goroutines
-				err = tCmd.Shutdown(&t.CmdArg{}, &[]t.Proc{})
+				err = ctrl.Shutdown()
 				return nil
 			case syscall.SIGHUP:
 				// stopping receiving request and handle current request
 				server.Shutdown()
 				// cleanup controller: stop all processes and goroutines
-				err = tCmd.Shutdown(&t.CmdArg{}, &[]t.Proc{})
+				err = ctrl.Shutdown()
 				slog.Info("server reloaded")
 			}
 		}


### PR DESCRIPTION
- As Is
   - Server hangs up when calling TaskCmd.Shutdown from client side
   - Since TaskCmd.Shutdown causes only controller's shutdown, it shouldn't be called from client side

- To Be
   - Client can't cause controller's shutdown except for signal
   - This functionality should be added in controller directly