### PR TITLE
fix: Got pid panic when sending SIGINT to the server after several operations. #31

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -103,7 +103,7 @@ func (t *TaskCmd) Start(req *CmdArg, resp *[]Proc) error {
 				return err
 			}
 		case *resp = <-procsCh:
-			if checkStatus(*resp, ProcStarting|ProcRunning, *req) {
+			if checkStatus(*resp, ProcStarting|ProcRunning|ProcBackoff, *req) {
 				return nil
 			}
 		case <-ctx.Done():


### PR DESCRIPTION


It seems to be happen when sending TaskCmd.Start multiple times. For solution, skip calling `startProc` when the process state is not startable.
Therefore, the caller in controller must change the status to startable before executing startProc.