### PR TITLE
fix: Can't receive client requests after reloading by SIGHUP #33

### DIFF
--- a/server/rpc.go
+++ b/server/rpc.go
@@ -37,8 +37,13 @@ func NewServer(path string, taskCmd *t.TaskCmd) (*server, error) {
 
 func (s *server) Serve() error {
 
+	rpc.DefaultServer = rpc.NewServer()
+
 	rpc.HandleHTTP()
-	rpc.Register(s.t)
+	err := rpc.Register(s.t)
+	if err != nil {
+		return err
+	}
 
 	return s.s.Serve(s.l)
 }


### PR DESCRIPTION
It happens because rpc.Register can't overwrite receiver's method. this function publishes the receiver's methods in the DefaultServer.

For solution, set rpc server as rpc.DefaultServer every time the server is created.

This error was hard to find because rpc.Register's error was ignored in server.Server() even though rpc.Register returns error. Therefore, made server.Serve() return rpc.Register's error.