### PR TITLE
fix: TaskServer becomes unresponsive after several instructions #38

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -118,7 +118,12 @@ func (c *controller) publish() {
 
 	procs := copyProcs(c.procs)
 	for pubCh, _ := range c.pubChs {
-		pubCh <- procs
+		select {
+		case pubCh <- procs:
+			slog.Debug("publish: published", "channel", fmt.Sprintf("%p", pubCh))
+		default:
+			slog.Debug("publish: skipped", "channel", fmt.Sprintf("%p", pubCh))
+		}
 	}
 }
 


### PR DESCRIPTION
It seems to happen when the controller tries to publish []ProcStatus to TaskCmd multiple times before TaskCmd reaches the select section.

If the number of published []ProcStatus messages exceeds the channel buffer size of TaskCmd, the Publish function blocks. But since TaskCmd hasn’t reached the select section yet, both routines become blocked and the situation never resolves.

solution: use select inside contoller.publish() to avoid deadlock.