### PR TITLE
fix: parse return empty objects when config omitted log/socket block itself #60

### DIFF
--- a/config.go
+++ b/config.go
@@ -69,6 +69,15 @@ func parseConfig(path string, cfg config.YamlConfig) (Config, error) {
 }
 
 func parseSocket(skt config.YamlSocket) (Socket, error) {
+	if skt.Path == "" {
+		return Socket{
+			Path: "/tmp/taskmaster.sock",
+			Mode: 0660,
+			UID:  os.Getuid(),
+			GID:  os.Getgid(),
+		}, nil
+	}
+
 	return Socket{
 		Path: skt.Path,
 		Mode: skt.Mode,
@@ -78,13 +87,16 @@ func parseSocket(skt config.YamlSocket) (Socket, error) {
 }
 
 func parseLog(log config.YamlLog) (Log, error) {
+	if log.Path == "" {
+		return Log{
+			Path:  "/tmp/taskmaster.log",
+			Level: slog.LevelInfo,
+		}, nil
+	}
+
 	level, err := parseLogLevel(log.Level)
 	if err != nil {
 		return Log{}, err
-	}
-
-	if log.Path == "" {
-		log.Path = "/tmp/taskmaster.log"
 	}
 
 	return Log{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,20 @@ type YamlLog struct {
 	Level string `yaml:"level"`
 }
 
+func (l *YamlLog) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type rawLog YamlLog
+	raw := rawLog{
+		Path:  "/tmp/taskmaster.log",
+		Level: "INFO",
+	}
+	if err := unmarshal(&raw); err != nil {
+		return err
+	}
+
+	*l = YamlLog(raw)
+	return nil
+}
+
 type YamlGroup struct {
 	Priority uint8                  `yaml:"priority"`
 	Programs map[string]YamlProgram `yaml:"programs"`


### PR DESCRIPTION
 use default settings when their paths are empty